### PR TITLE
Adding FakeDataset

### DIFF
--- a/datasets/Simulated.py
+++ b/datasets/Simulated.py
@@ -22,9 +22,12 @@ class Dataset(BaseDataset):
         # The return arguments of this function are passed as keyword arguments
         # to `Objective.set_data`. This defines the benchmark's
         # API to pass data. It is customizable for each benchmark.
-        dataset_name = "Zhou2016"
+
+        dataset_name = "FakeDataset"
         data = MOABBDataset(dataset_name=dataset_name,
-                            subject_ids=None)
+                            subject_ids=None,
+                            dataset_kwargs={"event_list": ["left_hand", "right_hand"],
+                                            "paradigm": "imagery"})
 
         dataset, sfreq = windows_data(data, 'LeftRightImagery')
 


### PR DESCRIPTION
Hi @tomMoral and @chris-mrn,

I solved the issue with [FakeDataset](https://github.com/NeuroTechX/moabb/blob/ce990b2b75ca0b66b570245a1094b645ef2e5e46/moabb/datasets/fake.py#L10) from moabb and Braindecode dataset. It is related to moabb PR, https://github.com/NeuroTechX/moabb/pull/414, and this PR. Now, we have a fake dataset to iterate to make an augmentation benchmark quickly.